### PR TITLE
SEO improvements

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://rinrin.pages.dev/sitemap.xml

--- a/src/lib/components/ArticleCard.svelte
+++ b/src/lib/components/ArticleCard.svelte
@@ -14,6 +14,11 @@
 
 	const slug = meta.slug ?? 'unreachable';
 	const date = idToDate(slug);
+	let datePlus9h: Date;
+	$: {
+		datePlus9h = new Date(date);
+		datePlus9h.setHours(datePlus9h.getHours() + 9);
+	}
 
 	const thumbnailImgFmt = thumbnailImgFmts?.[slug] ?? null;
 	const hasThumbnailImg = thumbnailImgFmt !== null;
@@ -33,7 +38,7 @@
 		</div>
 		<div class="meta">
 			<h2>{meta.title}</h2>
-			<time datetime={date.toISOString()}>
+			<time datetime={datePlus9h.toISOString()}>
 				{$dateI18n(date, { format: 'medium' })}
 			</time>
 			{#if meta.desc}

--- a/src/lib/components/Title.svelte
+++ b/src/lib/components/Title.svelte
@@ -44,7 +44,8 @@
 	@use '/assets/stylesheets/variables/mixin' as *;
 	@use '/assets/stylesheets/variables/color' as *;
 
-	h1, span::before {
+	h1,
+	span::before {
 		font-size: 36px;
 		margin: 0;
 		white-space: nowrap;
@@ -91,7 +92,8 @@
 	}
 
 	.mini {
-		h1, span::before {
+		h1,
+		span::before {
 			font-size: 26px;
 		}
 

--- a/src/lib/components/Title.svelte
+++ b/src/lib/components/Title.svelte
@@ -36,7 +36,7 @@
 
 <div class:mini={isOverflown}>
 	<h1 {id} bind:this={node}>{text}</h1>
-	<h1 class="shadow">{text}</h1>
+	<span data-content={text} />
 	<Space height="64px" />
 </div>
 
@@ -44,39 +44,40 @@
 	@use '/assets/stylesheets/variables/mixin' as *;
 	@use '/assets/stylesheets/variables/color' as *;
 
-	h1 {
+	h1, span::before {
 		font-size: 36px;
 		margin: 0;
 		white-space: nowrap;
 		position: absolute;
 		left: 50%;
 		@include bold;
+	}
 
-		&:not(.shadow) {
-			transform: translateX(-50%);
+	h1 {
+		transform: translateX(-50%);
 
-			&::before,
-			&::after {
-				content: '';
-				display: inline-block;
-				width: 64px;
-				height: 2px;
-				background-color: $line-primary;
-				vertical-align: middle;
-				white-space: nowrap;
-			}
+		&::before,
+		&::after {
+			content: '';
+			display: inline-block;
+			width: 64px;
+			height: 2px;
+			background-color: $line-primary;
+			vertical-align: middle;
+			white-space: nowrap;
+		}
 
-			&::before {
-				margin-right: 10px;
-			}
+		&::before {
+			margin-right: 10px;
+		}
 
-			&::after {
-				margin-left: 10px;
-			}
+		&::after {
+			margin-left: 10px;
 		}
 	}
 
-	.shadow {
+	span::before {
+		content: attr(data-content);
 		transform: translateX(-50%) scale(1, -1);
 		transform-origin: 50% 43px;
 		filter: blur(1.2px);
@@ -89,14 +90,20 @@
 		text-shadow: none;
 	}
 
-	.mini h1 {
-		font-size: 26px;
+	.mini {
+		h1, span::before {
+			font-size: 26px;
+		}
 
-		&:not(.shadow) {
+		h1 {
 			&::before,
 			&::after {
 				width: 16px;
 			}
+		}
+
+		span::before {
+			transform-origin: 50% 31px;
 		}
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 
 	const HEAD = {
 		title: 'Home',
-		desc: 'Rinrin.rs のホームページです'
+		desc: 'Rinrin.rs のホームページです。'
 	};
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,6 +29,8 @@
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
 	<meta property="og:url" content={SITE_URL} />
+
+	<link rel="canonical" href={SITE_URL} />
 </svelte:head>
 
 <img src="/images/icon_13_384px.webp" alt={$_('home.icon')} class="icn" />

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -16,7 +16,7 @@
 
 	export let data: PageData;
 
-	$: currentUrl = SITE_URL + '/blog';
+	$: canonicalUrl = SITE_URL + '/blog';
 
 	$: tags = data.tags;
 	$: articles = data.articles;
@@ -35,13 +35,15 @@
 
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
-	<meta property="og:url" content={currentUrl} />
+	<meta property="og:url" content={canonicalUrl} />
+
+	<link rel="canonical" href={canonicalUrl} />
 </svelte:head>
 
 <section>
 	<Space height="64px" />
 	<Title text="Blog" />
-	<p><ShareButton href={currentUrl} title={HEAD.titleFull} notArticlePage /><FeedButton /></p>
+	<p><ShareButton href={canonicalUrl} title={HEAD.titleFull} notArticlePage /><FeedButton /></p>
 	<TagPicker allTags={data.allTags} pickedTags={tags} />
 
 	{#if 0 < articles.length}

--- a/src/routes/blog/articles/[slug]/+page.svelte
+++ b/src/routes/blog/articles/[slug]/+page.svelte
@@ -30,6 +30,11 @@
 	$: parallax = parallaxStyle(scrollY);
 
 	$: date = idToDate(slug);
+	let datePlus9h: Date;
+	$: {
+		datePlus9h = new Date(date);
+		datePlus9h.setHours(datePlus9h.getHours() + 9);
+	}
 
 	$: thumbnailImgFmt = data.thumbnailImgFmt;
 	$: hasThumbnailImg = thumbnailImgFmt !== null;
@@ -95,7 +100,7 @@
 		<h1 style={parallax(-0.19)}>{metadata.title}</h1>
 	</div>
 	<div in:scale|global={introAnim(3)}>
-		<time datetime={date.toISOString()} style={parallax(-0.12)}
+		<time datetime={datePlus9h.toISOString()} style={parallax(-0.12)}
 			>{$dateI18n(date, { format: 'full' })}</time
 		>
 	</div>

--- a/src/routes/blog/articles/[slug]/+page.svelte
+++ b/src/routes/blog/articles/[slug]/+page.svelte
@@ -24,7 +24,7 @@
 	$: isPathnameEndsWithSlash = paths[pathnameLength - 1] === '';
 	$: slug = paths[pathnameLength - (isPathnameEndsWithSlash ? 2 : 1)];
 
-	$: currentUrl = SITE_URL + '/blog/articles/' + slug;
+	$: canonicalUrl = SITE_URL + '/blog/articles/' + slug;
 
 	let scrollY: number;
 	$: parallax = parallaxStyle(scrollY);
@@ -62,7 +62,7 @@
 
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
-	<meta property="og:url" content={currentUrl} />
+	<meta property="og:url" content={canonicalUrl} />
 	{#if hasThumbnailImg}
 		<meta property="og:image" content="{SITE_URL}{thumbnailPath}" />
 	{/if}
@@ -70,6 +70,8 @@
 	{#if !metadata.indexed}
 		<meta name="robots" content="noindex" />
 	{/if}
+
+	<link rel="canonical" href={canonicalUrl} />
 </svelte:head>
 
 <svelte:window bind:scrollY />
@@ -110,11 +112,11 @@
 			but breaking the logic for the sake of intuitiveness.
 		-->
 		<div style={parallax(-0.06)}>
-			<ShareButton href={currentUrl} title={HEAD.titleFull} /><FeedButton />
+			<ShareButton href={canonicalUrl} title={HEAD.titleFull} /><FeedButton />
 		</div>
 	</div>
 	<Article body={data.component} />
-	<p><ShareButton href={currentUrl} title={HEAD.titleFull} expanded /></p>
+	<p><ShareButton href={canonicalUrl} title={HEAD.titleFull} expanded /></p>
 	<Tags tags={metadata.tags} />
 	<div><a href="/blog" class="back-to-index">{$_('article.backToIndex')}</a></div>
 </div>

--- a/src/routes/creations/+page.svelte
+++ b/src/routes/creations/+page.svelte
@@ -7,7 +7,8 @@
 
 	const HEAD = {
 		title: 'Creations',
-		desc: 'Rinrin.rs の創作物'
+		desc: 'Rinrin.rs の創作物',
+		url: SITE_URL + '/creations'
 	};
 </script>
 
@@ -18,7 +19,9 @@
 
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
-	<meta property="og:url" content="{SITE_URL}/creations" />
+	<meta property="og:url" content={HEAD.url} />
+
+	<link rel="canonical" href={HEAD.url} />
 </svelte:head>
 
 <section>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -12,7 +12,8 @@
 
 	const HEAD = {
 		title: 'Profile',
-		desc: 'Rinrin.rs のプロフィール'
+		desc: 'Rinrin.rs のプロフィール',
+		url: SITE_URL + '/profile'
 	};
 </script>
 
@@ -23,7 +24,9 @@
 
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
-	<meta property="og:url" content="{SITE_URL}/profile" />
+	<meta property="og:url" content={HEAD.url} />
+
+	<link rel="canonical" href={HEAD.url} />
 </svelte:head>
 
 <section>

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -7,7 +7,8 @@
 
 	const HEAD = {
 		title: 'Dev. Projects',
-		desc: 'Rinrin.rs の開発プロジェクト'
+		desc: 'Rinrin.rs の開発プロジェクト',
+		url: SITE_URL + '/projects'
 	};
 </script>
 
@@ -18,7 +19,9 @@
 
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
-	<meta property="og:url" content="{SITE_URL}/projects" />
+	<meta property="og:url" content={HEAD.url} />
+
+	<link rel="canonical" href={HEAD.url} />
 </svelte:head>
 
 <section>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,62 @@
+import type { RequestHandler } from './$types';
+import { fetchArticles } from '$lib/fetchers';
+import { SITE_URL } from '$lib/variables';
+
+export const prerender = true;
+
+export const GET: RequestHandler = async ({ setHeaders }) => {
+	setHeaders({
+		'Cache-Control': 'max-age=0, s-maxage=86400',
+		'Content-Type': 'application/xml; charset=utf-8',
+	});
+	return new Response(await body());
+};
+
+async function body() {
+	const articles = (await fetchArticles({ isOnlyIndexed: true }))
+		.map((article) => `<url>
+        <loc>${SITE_URL}/blog/articles/${article.slug}</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>`).join('\n    ');
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>${SITE_URL}</loc>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>${SITE_URL}/profile</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>${SITE_URL}/blog</loc>
+        <changefreq>weekly</changefreq>
+        <priority>1.0</priority>
+    </url>
+	${articles}
+    <url>
+        <loc>${SITE_URL}/tools</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>${SITE_URL}/projects</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
+        <loc>${SITE_URL}/creations</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
+        <loc>${SITE_URL}/social</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+</urlset>`;
+}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -7,18 +7,21 @@ export const prerender = true;
 export const GET: RequestHandler = async ({ setHeaders }) => {
 	setHeaders({
 		'Cache-Control': 'max-age=0, s-maxage=86400',
-		'Content-Type': 'application/xml; charset=utf-8',
+		'Content-Type': 'application/xml; charset=utf-8'
 	});
 	return new Response(await body());
 };
 
 async function body() {
 	const articles = (await fetchArticles({ isOnlyIndexed: true }))
-		.map((article) => `<url>
+		.map(
+			(article) => `<url>
         <loc>${SITE_URL}/blog/articles/${article.slug}</loc>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
-    </url>`).join('\n    ');
+    </url>`
+		)
+		.join('\n    ');
 
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/src/routes/social/+page.svelte
+++ b/src/routes/social/+page.svelte
@@ -9,7 +9,8 @@
 
 	const HEAD = {
 		title: 'Social',
-		desc: 'Rinrin.rs のソーシャルアカウント一覧'
+		desc: 'Rinrin.rs のソーシャルアカウント一覧',
+		url: SITE_URL + '/social'
 	};
 </script>
 
@@ -20,7 +21,9 @@
 
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
-	<meta property="og:url" content="{SITE_URL}/social" />
+	<meta property="og:url" content={HEAD.url} />
+
+	<link rel="canonical" href={HEAD.url} />
 </svelte:head>
 
 <section>

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -7,7 +7,8 @@
 
 	const HEAD = {
 		title: 'Web Tools',
-		desc: '作った かすWebツール'
+		desc: '作った かすWebツール',
+		url: SITE_URL + '/tools'
 	};
 </script>
 
@@ -18,7 +19,9 @@
 
 	<meta property="og:title" content={HEAD.title} />
 	<meta property="og:description" content={HEAD.desc} />
-	<meta property="og:url" content="{SITE_URL}/tools" />
+	<meta property="og:url" content={HEAD.url} />
+
+	<link rel="canonical" href={HEAD.url} />
 </svelte:head>
 
 <section>


### PR DESCRIPTION
- 🛠️  #50
    - ⚗️ The `datetime` attribute value of articles is now added for 9 hours [e078fc01620e1e86f5441f9c422002f76cae84c1]
    - 🛠️ Added a Japanese period to the meta description of the top page [d2b2de724063ddc44bdb9750ab702a5dae1166ad]
    - ✨ Added a canonical URL for each page [20b24902fb9729ffda0ed4c65a19dd33a6d918eb]
    - ✨ #51 
        - ✨ Created a `/robots.txt` [80a2e65ac38afddefb3cddfe71701d7c0038f622]
    -  🛠️ The shadow element of the `Title` component is now a `span` tag, not a heading tag [5e83268d13a6fffad226fdd0e542808c1c3f7279]
