### PR TITLE
Article descriptions were default text

### DIFF
--- a/src/routes/blog/articles/[slug]/+page.svelte
+++ b/src/routes/blog/articles/[slug]/+page.svelte
@@ -57,7 +57,7 @@
 
 <HeadMetadata
 	title="Blog - {title}"
-	desc="Rinrin.rs のホームページです。"
+	desc={metadata.desc ?? ''}
 	{canonicalUrl}
 	ogType="article"
 	ogCardType="summary_large_image"


### PR DESCRIPTION
- 🐛 The description metadata on the article pages were the default description text instead of the descriptions for each articles [#65]
