### PR TITLE
Improve Focus Order And Focus Indicator

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -7,6 +7,7 @@
 | Z-Index | Entity | Path |
 | --: | --- | --- |
 | 1031 | nprogress { bar, spinner }  | [`/node_modules/nprogress/nprogress.css>#nprogress .bar`](/node_modules/nprogress/nprogress.css), [`/node_modules/nprogress/nprogress.css>#nprogress .spinner`](/node_modules/nprogress/nprogress.css) |
+| 132 | header skip btn | [`header.scss>.skip-btn`](/src/lib/stylesheets/header/header.scss) |
 | 129 | header logo | [`header.scss>.header-logo img`](/src/lib/stylesheets/header/header.scss) |
 | 128 | header title | [`header.scss>.header-logo::after`](/src/lib/stylesheets/header/header.scss) |
 | 127 | header, header bg | [`header.scss>header, .header-bg`](/src/lib/stylesheets/header/header.scss) |

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -123,23 +123,24 @@
 					</ul>
 				</nav>
 				<div class="lang">
-					{#if isLocaleEng}
-						<button on:click={() => locale.set('ja')} class="active">日本語</button>
-					{:else}
-						<button disabled>日本語</button>
-					{/if}
+					<button
+						on:click={() => {
+							if (isLocaleEng) locale.set('ja');
+						}}
+						class="active"
+						disabled={!isLocaleEng}>日本語</button
+					>
 					|
-					{#if isLocaleEng}
-						<button disabled>English</button>
-					{:else}
-						<button
-							on:click={() => {
+					<button
+						on:click={() => {
+							if (!isLocaleEng) {
 								locale.set('en');
 								alert('Some parts may not be translated.');
-							}}
-							class="active">English</button
-						>
-					{/if}
+							}
+						}}
+						class="active"
+						disabled={isLocaleEng}>English</button
+					>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/ShareButton.svelte
+++ b/src/lib/components/ShareButton.svelte
@@ -32,6 +32,9 @@
 
 	let mastodonDomain = 'mastodon.social';
 
+	let firstItem: HTMLElement;
+	$: if (!expanded) firstItem?.focus();
+
 	function toggleDropdownMenu() {
 		isMenuOpened = !isMenuOpened;
 	}
@@ -92,7 +95,7 @@
 		transition:fly={{ ...ANIM_OFFSET, duration: 200 }}
 	>
 		<li>
-			<button on:click={copyToClipboard} title={ITEM_NAMES.copy}>
+			<button on:click={copyToClipboard} title={ITEM_NAMES.copy} bind:this={firstItem}>
 				<!--
 					Google Material Symbols and Icons - Content Copy
 					https://fonts.google.com/icons?selected=Material%20Symbols%20Outlined%3Acontent_copy%3AFILL%400%3Bwght%40400%3BGRAD%400%3Bopsz%4024

--- a/src/lib/components/header/HamburgerButton.svelte
+++ b/src/lib/components/header/HamburgerButton.svelte
@@ -5,7 +5,10 @@
 	const dispatch = createEventDispatcher();
 </script>
 
-<button on:click={() => isDrawerMenuOpened.update((prev) => !prev)} on:focus={() => dispatch('focus')}>
+<button
+	on:click={() => isDrawerMenuOpened.update((prev) => !prev)}
+	on:focus={() => dispatch('focus')}
+>
 	{#if $isDrawerMenuOpened}
 		<!--
 			Google Material Symbols and Icons - Close

--- a/src/lib/components/header/HamburgerButton.svelte
+++ b/src/lib/components/header/HamburgerButton.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import { isDrawerMenuOpened } from '$lib/scripts/stores';
+
+	const dispatch = createEventDispatcher();
 </script>
 
-<button on:click={() => isDrawerMenuOpened.update((prev) => !prev)}>
+<button on:click={() => isDrawerMenuOpened.update((prev) => !prev)} on:focus={() => dispatch('focus')}>
 	{#if $isDrawerMenuOpened}
 		<!--
 			Google Material Symbols and Icons - Close

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -62,6 +62,7 @@
 
 <div class="header-bg" class:blur={isMainVisual} />
 <header class:backdrop-blur={!isMainVisual}>
+	<a href="#main-content" class="skip-btn" on:focus={forceSetTheAtTopFalse}>{$_('header.skip')}</a>
 	<nav class:opened={$isDrawerMenuOpened} class:at-top={isMainVisual}>
 		{#each ITEMS as item}
 			<a href="/{item.id}" class="item" class:active={pathname.split('/')[1] === item.id} on:focus={forceSetTheAtTopFalse}>

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -62,7 +62,12 @@
 
 <div class="header-bg" class:blur={isMainVisual} />
 <header class:backdrop-blur={!isMainVisual}>
-	<a href="#main-content" class="skip-btn" on:focus={forceSetTheAtTopFalse}>{$_('header.skip')}</a>
+	<a
+		href="#main-content"
+		class="skip-btn"
+		on:focus={forceSetTheAtTopFalse}
+		inert={$isDrawerMenuOpened}>{$_('header.skip')}</a
+	>
 	<nav class:opened={$isDrawerMenuOpened} class:at-top={isMainVisual}>
 		{#each ITEMS as item}
 			<a

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -53,20 +53,25 @@
 	function updateScroll() {
 		isAtTop = window.scrollY <= 0;
 	}
+
+	/** Forcibly set the `AtTop` variable to `false`. */
+	function forceSetTheAtTopFalse() {
+		isAtTop = false;
+	}
 </script>
 
 <div class="header-bg" class:blur={isMainVisual} />
 <header class:backdrop-blur={!isMainVisual}>
 	<nav class:opened={$isDrawerMenuOpened} class:at-top={isMainVisual}>
 		{#each ITEMS as item}
-			<a href="/{item.id}" class="item" class:active={pathname.split('/')[1] === item.id}>
+			<a href="/{item.id}" class="item" class:active={pathname.split('/')[1] === item.id} on:focus={forceSetTheAtTopFalse}>
 				<Icon id={item.id} />
 				<span class="item-text">{$_(item.name)}</span>
 			</a>
 		{/each}
 	</nav>
 	<div class="hamburger-btn" class:hidden={isMainVisual}>
-		<HamburgerButton /><LangButton />
+		<HamburgerButton on:focus={forceSetTheAtTopFalse} /><LangButton on:focus={forceSetTheAtTopFalse} />
 	</div>
 	<a
 		href="/"

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -80,7 +80,8 @@
 		class:fade-in={enableFadeIn}
 		on:click={() => {
 			isDrawerMenuOpened.set(false);
-		}}><img src="/images/logos/rinrin/logo.svg" alt={$_('header.logo')} /></a
+		}}
+		tabindex="-1"><img src="/images/logos/rinrin/logo.svg" alt={$_('header.logo')} /></a
 	>
 </header>
 

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -65,14 +65,21 @@
 	<a href="#main-content" class="skip-btn" on:focus={forceSetTheAtTopFalse}>{$_('header.skip')}</a>
 	<nav class:opened={$isDrawerMenuOpened} class:at-top={isMainVisual}>
 		{#each ITEMS as item}
-			<a href="/{item.id}" class="item" class:active={pathname.split('/')[1] === item.id} on:focus={forceSetTheAtTopFalse}>
+			<a
+				href="/{item.id}"
+				class="item"
+				class:active={pathname.split('/')[1] === item.id}
+				on:focus={forceSetTheAtTopFalse}
+			>
 				<Icon id={item.id} />
 				<span class="item-text">{$_(item.name)}</span>
 			</a>
 		{/each}
 	</nav>
 	<div class="hamburger-btn" class:hidden={isMainVisual}>
-		<HamburgerButton on:focus={forceSetTheAtTopFalse} /><LangButton on:focus={forceSetTheAtTopFalse} />
+		<HamburgerButton on:focus={forceSetTheAtTopFalse} /><LangButton
+			on:focus={forceSetTheAtTopFalse}
+		/>
 	</div>
 	<a
 		href="/"

--- a/src/lib/components/header/LangButton.svelte
+++ b/src/lib/components/header/LangButton.svelte
@@ -2,7 +2,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import { locale, _ } from 'svelte-i18n';
 
-const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 </script>
 
 <button

--- a/src/lib/components/header/LangButton.svelte
+++ b/src/lib/components/header/LangButton.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import { locale, _ } from 'svelte-i18n';
+
+const dispatch = createEventDispatcher();
 </script>
 
 <button
@@ -11,6 +14,7 @@
 			alert('Some parts may not be translated.');
 		}
 	}}
+	on:focus={() => dispatch('focus')}
 >
 	<!--
 		Google Material Symbols and Icons - Language

--- a/src/lib/components/home/Chronicle.svelte
+++ b/src/lib/components/home/Chronicle.svelte
@@ -21,7 +21,7 @@
 		class="container"
 		title={!isOpened ? 'Open' : ''}
 		role="button"
-		tabindex="0"
+		tabindex={isOpened ? -1 : 0}
 		on:click|once={open}
 		on:keypress|once={(e) => {
 			if (e.key === 'Enter') open();

--- a/src/lib/components/home/Chronicle.svelte
+++ b/src/lib/components/home/Chronicle.svelte
@@ -24,7 +24,7 @@
 		tabindex="0"
 		on:click|once={open}
 		on:keypress|once={(e) => {
-			if (e.key === 'Enter') open;
+			if (e.key === 'Enter') open();
 		}}
 	>
 		<ul class:opened={isOpened}>

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -53,7 +53,8 @@
 	},
 	"header": {
 		"logo": "Rinrin.rs' logo",
-		"language": "日本語"
+		"language": "日本語",
+		"skip": "Skip to main content"
 	},
 	"footer": {
 		"bgWallpaper": "Wallpaper"

--- a/src/lib/locales/ja.json
+++ b/src/lib/locales/ja.json
@@ -53,7 +53,8 @@
 	},
 	"header": {
 		"logo": "Rinrin.rsのロゴ",
-		"language": "English"
+		"language": "English",
+		"skip": "コンテンツへ進む"
 	},
 	"footer": {
 		"bgWallpaper": "背景壁紙"

--- a/src/lib/scripts/stores.ts
+++ b/src/lib/scripts/stores.ts
@@ -4,5 +4,8 @@ import { toggleScrollPrevention } from '$lib/scripts/utils';
 
 export const isDrawerMenuOpened = writable(false);
 isDrawerMenuOpened.subscribe((value) => {
-	if (browser) toggleScrollPrevention(value);
+	if (browser) {
+		toggleScrollPrevention(value);
+		if (value) document.querySelector<HTMLElement>('footer li a')?.focus();
+	}
 });

--- a/src/lib/stylesheets/header/header.scss
+++ b/src/lib/stylesheets/header/header.scss
@@ -127,6 +127,26 @@ header {
 	}
 }
 
+.skip-btn {
+	position: absolute;
+	top: 0;
+	left: 0;
+	font-size: 22px;
+	@include bold($color: $bg-primary);
+	color: $bg-primary;
+	background-color: $txt-primary;
+	padding: 12px 18px;
+	border-bottom-right-radius: 14px;
+	text-decoration: none;
+	outline-offset: 0;
+	transition: 0.25s ease-out;
+	z-index: 132;
+
+	&:not(:focus) {
+		transform: translate(-130%, -110%);
+	}
+}
+
 nav {
 	display: flex;
 	justify-content: right;

--- a/src/lib/stylesheets/style.scss
+++ b/src/lib/stylesheets/style.scss
@@ -6,6 +6,28 @@
 	scrollbar-color: #2b1d0e transparent;
 	scroll-margin-top: $header-height + 18px;
 	font-weight: 500;
+	outline: 12px solid transparent;
+}
+
+:focus-visible {
+	$focus-col: #00b0ff;
+	outline: 3px solid $focus-col;
+	outline-offset: 2px;
+	animation: flash 0.5s;
+	overflow: visible;
+	transition: outline 0.3s ease-in;
+
+	@keyframes flash {
+		0% {
+			outline-color: black;
+		}
+		50% {
+			outline-color: white;
+		}
+		100% {
+			outline-color: $focus-col;
+		}
+	}
 }
 
 ::selection {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -90,7 +90,7 @@
 
 <Header />
 
-<main id="main-content"><slot /></main>
+<main id="main-content" inert={$isDrawerMenuOpened}><slot /></main>
 
 <Footer />
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -90,7 +90,7 @@
 
 <Header />
 
-<main><slot /></main>
+<main id="main-content"><slot /></main>
 
 <Footer />
 


### PR DESCRIPTION
- ♿ Improve the focus order and the focus indicator style [#70]
    - ✨ Added "Skip to main content" button to the header [68dfaa0d45812c158b3d094918b82d30a5ad0308]
    - ♿  The header items are now displayed when any header item is focused [8498365314bbc38dd2532f17da82be4624560d3a]
    - ♿ When the drawer menu opens, the background content is no longer focusable [f90b8e3b6c25488e753e49e0aaba7154b446d7d7]
    - 🐛 The Chronicle Card can now be opened with a keyboard [bb5704338ad0569026daf12de09ab93feb0f3fa0]
    - ♿ When the drawer menu opens, the focus indicator is set to the first item [8acfed81f698275fd6ead4e8741ec91fa659020e]
    - ♿ When the Sharing Menu opens, the focus indicator is set to the first item [b272c4434236573f3c9dd69a1edd39ae078e170c]
    - 🛠️ The Chronicle Card is no longer focusable once opened [ea6e1302c5760a2583438bf53e4d7f14afd6678c]
    - 🛠️ The header icon is no longer focusable [179edfa6d572500e86639387e01b0a5f758b2856]
    - ♿ The focus indicator no longer gets reset when switching the language in the footer [fc7a48a9f5e269dbe813ff47c11974f455535aa8]
