### PR TITLE
Make blog pages support no-JS env.

### DIFF
--- a/src/lib/components/header/LangButton.svelte
+++ b/src/lib/components/header/LangButton.svelte
@@ -30,6 +30,8 @@
 </button>
 
 <style lang="scss">
+	@use '$lib/stylesheets/variables/mixin' as *;
+
 	@use '$lib/stylesheets/header/button';
 
 	button {
@@ -55,9 +57,7 @@
 			}
 		}
 
-		@media (scripting: none) {
-			display: none;
-		}
+		@include hideWhenNoJs;
 	}
 
 	span {

--- a/src/lib/stylesheets/blog/share_button.scss
+++ b/src/lib/stylesheets/blog/share_button.scss
@@ -25,6 +25,7 @@
 
 .share-btn {
 	@include btn;
+	@include hideWhenNoJs;
 }
 
 svg {
@@ -38,6 +39,8 @@ svg {
 
 ul {
 	list-style: none;
+
+	@include hideWhenNoJs;
 
 	&.menu {
 		display: inline-block;

--- a/src/lib/stylesheets/variables/_mixin.scss
+++ b/src/lib/stylesheets/variables/_mixin.scss
@@ -30,6 +30,12 @@ $breakpoint-ultra-narrow: 380px;
 	}
 }
 
+@mixin hideWhenNoJs {
+	@media (scripting: none) {
+		display: none;
+	}
+}
+
 @mixin glassmorphism(
 	$blur: 10px,
 	$background-color: #ffffff35,

--- a/src/routes/blog/Tag.svelte
+++ b/src/routes/blog/Tag.svelte
@@ -32,6 +32,7 @@
 	<button on:click={toggle} class="tag-btn">
 		{name.toUpperCase()}({count})
 	</button>
+	<a href="/blog{isEnabled ? '' : '?t=' + name}" class="tag-btn">{name.toUpperCase()}({count})</a>
 </li>
 
 <style lang="scss">
@@ -51,6 +52,16 @@
 			@include sp {
 				opacity: $disabled-opacity;
 			}
+		}
+	}
+
+	button {
+		@include hideWhenNoJs;
+	}
+
+	a {
+		@media (scripting: enabled) {
+			display: none;
 		}
 	}
 </style>


### PR DESCRIPTION
- ♿ The blog pages (`/blog`, `/blog/articles/*`) now support the environments where JavaScript is disabled [#82]
    - ✨ Added `hideWhenNoJs` mixin [2e01e5d1a1afde3e78442f0da36743a05770f8ca]
