### PR TITLE
Tags in artwork cards are no longer converted to uppercase

### DIFF
--- a/src/lib/components/creations/ArtworkCard.svelte
+++ b/src/lib/components/creations/ArtworkCard.svelte
@@ -36,7 +36,7 @@
 				<ul>
 					<li class="category">{meta.category}</li>
 					{#each meta.tags as tag}
-						<li><span class="tag-btn">{tag.toUpperCase()}</span></li>
+						<li><span class="tag-btn">{tag}</span></li>
 					{/each}
 				</ul>
 			</div>


### PR DESCRIPTION
- 🩹 Tags in artwork cards are no longer converted to uppercase [#112]
