### PR TITLE
Default value for `awake2sleep-inferencer` is now multiple of 0.5

### DIFF
--- a/src/routes/tools/awake2sleep-inferencer/+page.svelte
+++ b/src/routes/tools/awake2sleep-inferencer/+page.svelte
@@ -40,7 +40,8 @@
 
 	Chart.register(...registerables);
 
-	let awakeDuration = parseFloat(DATASET.stats.awake.mean.toFixed(1));
+	// The default value should be a multiple of 0.5 because the `<input>` element and graph steps are 0.5.
+	let awakeDuration = Math.round(DATASET.stats.awake.mean * 2) * 0.5;
 
 	$: sleepDurations = DATASET.regrModels.reduce(
 		(acc, model) => {


### PR DESCRIPTION
- 🩹 The default input value for the web tool `awake2sleep-inferencer` could have been other than multiple of 0.5 [#133]
